### PR TITLE
Denies "suggest" user direct messages

### DIFF
--- a/commands/voting/suggest.js
+++ b/commands/voting/suggest.js
@@ -14,6 +14,13 @@ module.exports = class SuggestCommand extends Commando.Command {
   }
 
   async run (message, args) {
+
+    if(message.channel.type === 'dm') {
+      message.channel
+        .send(`Questo comando non è utilizzabile nei messaggi diretti`);
+        return
+    }
+
     if(message.channel.name !== suggestionChannel) {
       const channelId = message.guild.channels.cache.find(channel => channel.name === suggestionChannel);
       message.channel

--- a/commands/voting/suggestion-status.js
+++ b/commands/voting/suggestion-status.js
@@ -17,6 +17,12 @@ module.exports = class SuggestionStatusCommand extends Commando.Command {
   async run (message, args) {
     if(!args) return;
 
+    if(message.channel.type === 'dm') {
+      message.channel
+        .send(`Questo comando non è utilizzabile nei messaggi diretti`);
+        return
+    }
+
     let statusMessage = '';
     let statusColor = '';
     const targetMessage = await message.channel.messages.fetch(args[0]);


### PR DESCRIPTION
When a 'suggest' category command is written in a direct message, incoming [DMChannel Class](https://discord.js.org/#/docs/main/stable/class/DMChannel) object doesn't contain properties required by these commands, making bot return an error.

Solution was taken by checking type property inherited from [Channel Class](https://discord.js.org/#/docs/main/master/class/Channel)

Closes #6